### PR TITLE
Remove warnings and exceptions for local backend

### DIFF
--- a/exaqute/local/functions.py
+++ b/exaqute/local/functions.py
@@ -66,18 +66,8 @@ def _delete_object(obj):
             )
         if obj.deleted:
             raise ExaquteException(
-                "Deleting already deleted object, object created at {}".format(
-                    obj.traceback
-                )
+                "Deleting already deleted object, object created at {}".format(obj.traceback)
             )
         obj.deleted = True
-    else:
-        if not isinstance(obj, (bool, int, float, str)):
-            if not _check_accessed(obj):
-                raise ExaquteException(
-                    "delete_object called on non-task value, got {!r}".format(obj)
-                    + " type "
-                    + str(t)
-                )
-            else:
-                _delete_accessed(obj)
+    elif not isinstance(obj, (bool, int, float, str)) and _check_accessed(obj):
+        _delete_accessed(obj)

--- a/exaqute/local/functions.py
+++ b/exaqute/local/functions.py
@@ -29,18 +29,9 @@ def get_value_from_remote(obj):
             )
         return obj.unwrap_value()
     else:
-        if isinstance(obj, (int, bool, float, str)):
-            return obj
-        else:
-            if not _check_accessed(obj):
-                print(
-                    "WARN: get_value_from_remote called on non-task value, got {!r}".format(
-                        obj
-                    )
-                )
-            else:
-                _delete_accessed(obj)
-            return obj
+        if not isinstance(obj, (int, bool, float, str)) and _check_accessed(obj):
+            _delete_accessed(obj)
+        return obj
 
 
 def barrier():


### PR DESCRIPTION
These changes affect only the local backend.

# Issue

In the backends for PyCOMPSs of Quake, the functions in the `exaqute` module send warnings or even exceptions when some operations are attempted on a non-task value.

Some of the code for these warnings and exceptions seem to have been copied in the local backend. This is a problem: for this backend, the objects passed as arguments will _never_ be task values, therefore the warnings and exceptions will _always_ be raised.

# Proposed change

I have removed one warning and one exception that we have faced while using the `exaqute` module with the local backend.

There are certainly others that could be removed, and there may be other simplifications possible. Since I am not familiar with this module, I have taken a conservative approach and only fixed the problems we encountered in our use.

Any comment or suggestion is welcome, of course.