### PR TITLE
Support "local" as value for EXAQUTE_BACKEND

### DIFF
--- a/exaqute/__init__.py
+++ b/exaqute/__init__.py
@@ -2,18 +2,21 @@ import os
 
 from .common import *  # noqa
 
-exacute_backend = os.environ.get("EXAQUTE_BACKEND")
-print("EXAQUTE_BACKEND=", exacute_backend)
+exaqute_backend = os.environ.get("EXAQUTE_BACKEND")
 
-if exacute_backend:
-    exacute_backend = exacute_backend.lower()
-
-if not exacute_backend:
-    print("ExaQUte backend: Local")
-    from .local import *  # noqa
-elif exacute_backend == "hyperloom":
-    from .hyperloom import *  # noqa
-elif exacute_backend == "pycompss":
-    from .pycompss import *  # noqa
+if exaqute_backend:
+    print("EXAQUTE_BACKEND={}".format(exaqute_backend))
 else:
-    raise Exception("Unknown exaqute backend: {}".format(exacute_backend))
+    exaqute_backend = "local"
+    print("Default ExaQUte backend: {}".format(exaqute_backend))
+
+exaqute_backend = exaqute_backend.lower()
+
+if exaqute_backend == "local":
+    from .local import *  # noqa
+elif exaqute_backend in ("quake", "pycompss"):
+    raise ModuleNotFoundError(
+        "ExaQUte backend known but not found: {}".format(exaqute_backend)
+    )
+else:
+    raise ModuleNotFoundError("Unknown ExaQUte backend: {}".format(exaqute_backend))

--- a/exaqute/__init__.py
+++ b/exaqute/__init__.py
@@ -14,9 +14,14 @@ exaqute_backend = exaqute_backend.lower()
 
 if exaqute_backend == "local":
     from .local import *  # noqa
-elif exaqute_backend in ("quake", "pycompss"):
-    raise ModuleNotFoundError(
-        "ExaQUte backend known but not found: {}".format(exaqute_backend)
-    )
+elif exaqute_backend == "hyperloom":
+    from .hyperloom import *  # noqa
+elif exaqute_backend == "pycompss":
+    from .pycompss import *  # noqa
 else:
-    raise ModuleNotFoundError("Unknown ExaQUte backend: {}".format(exaqute_backend))
+    raise ModuleNotFoundError(
+        (
+            "Unknown ExaQUte backend: {}\n"
+            "Supported values are 'local', 'hyperloom' and 'pycompss'"
+        ).format(exaqute_backend)
+    )


### PR DESCRIPTION
# Motivation 

Currently, the only way to select the local backend is to unset the `EXAQUTE_BACKEND` variable in the environment.

I would like to be able to choose explictly the local backend with the value I set to `EXAQUTE_BACKEND`, not just as a fallback option. It is not necessary but I find it more intuitive, and it makes the experience easier in many small ways (e.g. shell scripting, checking the environment, etc.).

# Proposed change

`"local"` is an accepted value for `EXAQUTE_BACKEND`. As before, the message printed is slightly different depending on whether the backend was chosen explicitly or set by default.

Also, the error messages for other values of `EXAQUTE_BACKEND` (supported or not) are a bit more informative.

Feel free to edit, suggest, comment, etc.