### PR TITLE
Improve formatting of error message in ValueWrapper.unwrap_value

### DIFF
--- a/exaqute/local/internals.py
+++ b/exaqute/local/internals.py
@@ -36,8 +36,7 @@ class ValueWrapper:
             raise ExaquteException("Using deleted object")
         if not self.keep and self not in _temp_objects:
             raise ExaquteException(
-                "Using temporary object after submit point, object created at {}",
-                self.traceback,
+                f"Using temporary object after submit point, object created at {self.traceback}",
             )
         return _obj_to_value(self.value)
 

--- a/exaqute/local/internals.py
+++ b/exaqute/local/internals.py
@@ -36,7 +36,7 @@ class ValueWrapper:
             raise ExaquteException("Using deleted object")
         if not self.keep and self not in _temp_objects:
             raise ExaquteException(
-                f"Using temporary object after submit point, object created at {self.traceback}",
+                f"Using temporary object after submit point, object created at:\n{self.traceback}",
             )
         return _obj_to_value(self.value)
 


### PR DESCRIPTION
# Current behaviour

The error message from `ValueWrapper.unwrap_value` is strangely formatted:

```shell
File "/.../exaqute/local/internals.py", line 38, in unwrap_value
    raise ExaquteException(
exaqute.common.exception.ExaquteException: ('Using temporary object after submit point, object created at {}', '  File "/.../xmc/monteCarloSampler.py", line 379, in update\n    self.indices[i].update(newHierarchy[i])\n  File "/.../xmc/monteCarloIndex.py", line 239, in update\n    self.costEstimator.update([[t] for t in total_time])\n  File "/.../xmc/momentEstimator.py", line 76, in update\n    self._powerSums = self._powerSumsUpdater(self._powerSums, samples)\n  File "/.../exaqute/local/decorators.py", line 76, in wrapped_task\n    return ValueWrapper(result, keep)\n  File "/.../exaqute/local/internals.py", line 30, in __init__\n    self.traceback = _traceback()\n')
```

Relevant lines from `ValueWrapper.unwrap_value` in `internals.py`:

```python
raise ExaquteException(
    "Using temporary object after submit point, object created at {}",
    self.traceback,
)
```

# Proposed change

The `{}` in the string makes me suspect that this formatting is not deliberate. I changed it to

```python
raise ExaquteException(
    f"Using temporary object after submit point, object created at:\n{self.traceback}",
)
```

New formatting:
```shell
  File "/.../exaqute/local/internals.py", line 38, in unwrap_value
    raise ExaquteException(
exaqute.common.exception.ExaquteException: Using temporary object after submit point, object created at:
  File "/.../xmc/monteCarloSampler.py", line 379, in update
    self.indices[i].update(newHierarchy[i])
  File "/.../xmc/monteCarloIndex.py", line 239, in update
    self.costEstimator.update([[t] for t in total_time])
  File "/.../xmc/momentEstimator.py", line 76, in update
    self._powerSums = self._powerSumsUpdater(self._powerSums, samples)
  File "/.../exaqute/local/decorators.py", line 76, in wrapped_task
    return ValueWrapper(result, keep)
  File "/.../exaqute/local/internals.py", line 30, in __init__
    self.traceback = _traceback()
```

I propose to contribute this (very minor) change upstream.
